### PR TITLE
Add February 2024 Data

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ This repository aims to address the accessibility issue by providing CSV dataset
 The PDF sources are listed below:
 
 ## 2024 
+- [February](https://abca.dc.gov/sites/default/files/dc/sites/abra/page_content/attachments/MCP%20Report%20-%20February%202024.pdf)
 - [January](https://abca.dc.gov/sites/default/files/dc/sites/abra/page_content/attachments/MCP%20Metrics%20-%20January%202024.pdf)
 
 ## 2023

--- a/data/monthly-sales.csv
+++ b/data/monthly-sales.csv
@@ -59,3 +59,6 @@ Medical Cannabis Program Report | December 2023,2023-12-01T00:00:00Z,Manufacture
 Medical Cannabis Program Report | January 2024,2024-01-01T00:00:00Z,Dispensaries,2596311
 Medical Cannabis Program Report | January 2024,2024-01-01T00:00:00Z,Cultivation Centers,921144
 Medical Cannabis Program Report | January 2024,2024-01-01T00:00:00Z,Manufacturer,485038
+Medical Cannabis Program Report | February 2024,2024-02-01T00:00:00Z,Dispensaries,2509642
+Medical Cannabis Program Report | February 2024,2024-02-01T00:00:00Z,Cultivation Centers,1109859
+Medical Cannabis Program Report | February 2024,2024-02-01T00:00:00Z,Manufacturer,509929

--- a/data/patients.csv
+++ b/data/patients.csv
@@ -67,3 +67,6 @@ Medical Cannabis Program Report | December 2023,2023-12-01T00:00:00Z,Non-DC Resi
 Medical Cannabis Program Report | January 2024,2024-01-01T00:00:00Z,DC Residents,6079,15721,14414,1307,92,87,152,1247683,198317,1446000
 Medical Cannabis Program Report | January 2024,2024-01-01T00:00:00Z,Non-DC Residents,2098,4508,4470,38,152,151,183,676609,6968,683578
 Medical Cannabis Program Report | January 2024,2024-01-01T00:00:00Z,Non-DC Residents (Self-Certified Temporary),1774,3021,2974,47,154,154,195,457590,9144,466734
+Medical Cannabis Program Report | February 2024,2024-02-01T00:00:00Z,DC Residents,5731,14698,13554,1144,94,88,158,1196954,180355,1377308
+Medical Cannabis Program Report | February 2024,2024-02-01T00:00:00Z,Non-DC Residents,2024,4377,4335,42,156,156,160,676789,6703,683492
+Medical Cannabis Program Report | February 2024,2024-02-01T00:00:00Z,Non-DC Residents (Self-Certified Temporary),1662,2890,2851,39,155,155,206,440811,8031,448842

--- a/data/product-sales-by-type.csv
+++ b/data/product-sales-by-type.csv
@@ -208,3 +208,14 @@ Medical Cannabis Program Report | January 2024,2024-01-01T00:00:00Z,Raw Pre-Roll
 Medical Cannabis Program Report | January 2024,2024-01-01T00:00:00Z,Shake/Trim,18,LBS,77262
 Medical Cannabis Program Report | January 2024,2024-01-01T00:00:00Z,Tincture,64,LBS,150129
 Medical Cannabis Program Report | January 2024,2024-01-01T00:00:00Z,Vape Cartridge,151,EACH,12836
+Medical Cannabis Program Report | February 2024,2024-02-01T00:00:00Z,Concentrate,616,G,45244
+Medical Cannabis Program Report | February 2024,2024-02-01T00:00:00Z,Flower/Bud,346,LBS,1573878
+Medical Cannabis Program Report | February 2024,2024-02-01T00:00:00Z,Infused Concentrate,8811,EACH,339093
+Medical Cannabis Program Report | February 2024,2024-02-01T00:00:00Z,Edibles,5569,EACH,155748
+Medical Cannabis Program Report | February 2024,2024-02-01T00:00:00Z,Infused Topical,1.3,EACH,13234
+Medical Cannabis Program Report | February 2024,2024-02-01T00:00:00Z,Kief,367,G,13232
+Medical Cannabis Program Report | February 2024,2024-02-01T00:00:00Z,Pill/Capsule/Suppository,245,EACH,10274
+Medical Cannabis Program Report | February 2024,2024-02-01T00:00:00Z,Raw Pre-Roll,906,EACH,40785
+Medical Cannabis Program Report | February 2024,2024-02-01T00:00:00Z,Shake/Trim,20,LBS,82680
+Medical Cannabis Program Report | February 2024,2024-02-01T00:00:00Z,Tincture,66,LBS,155083
+Medical Cannabis Program Report | February 2024,2024-02-01T00:00:00Z,Vape Cartridge,362,EACH,17573

--- a/data/program-participation.csv
+++ b/data/program-participation.csv
@@ -27,3 +27,4 @@ Medical Cannabis Program Report | October 2023,2023-10-01T00:00:00Z,24384,63,653
 Medical Cannabis Program Report | November 2023,2023-11-01T00:00:00Z,24819,63,654,11092
 Medical Cannabis Program Report | December 2023,2023-12-01T00:00:00Z,25027,63,655,11525
 Medical Cannabis Program Report | January 2024,2024-01-01T00:00:00Z,25191,66,657,9951
+Medical Cannabis Program Report | February 2024,2024-02-01T00:00:00Z,25228,68,657,9417


### PR DESCRIPTION
February data was finally published!

Some notes:
- still appears to be some weird entries in `Product Sales by Type`, see the screenshot below where `Kief` has no unit but `Pill/Capsule/Suppository` has `G` when its apparently supposed to be "each"?
![Screenshot 2024-03-18 at 1 31 22 PM](https://github.com/mistermichaelll/DC-Cannabis-Data/assets/33233019/c386d1b3-1d7e-4dd6-b9a0-06784ade4ae0)

